### PR TITLE
Removed deprecated 'feInterface' definition

### DIFF
--- a/Configuration/TCA/tt_address.php
+++ b/Configuration/TCA/tt_address.php
@@ -19,9 +19,6 @@ return array(
         'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('tt_address') . 'ext_icon.gif',
         'searchFields' => 'name, first_name, middle_name, last_name, email',
     ),
-    'feInterface' => array(
-        'fe_admin_fieldList' => 'pid,hidden,gender,first_name,middle_name,last_name,title,address,building,room,birthday,phone,fax,mobile,www,email,city,zip,company,region,country,image,description'
-    ),
     'interface' => array(
         'showRecordFieldList' => 'first_name,middle_name,last_name,address,building,room,city,zip,region,country,phone,fax,email,www,title,company,image'
     ),


### PR DESCRIPTION
Having a 'feInterface' definition in Configuration/TCA/tt_address.php creates deprecation log warnings and serves no purpose in >= TYPO3 6.2, so remove it.