### PR TITLE
[BUGFIX] fixed placeholderImage output

### DIFF
--- a/pi1/class.tx_ttaddress_pi1.php
+++ b/pi1/class.tx_ttaddress_pi1.php
@@ -416,7 +416,7 @@ class tx_ttaddress_pi1 extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin
             $iConf['altText'] = !empty($iConf['altText']) ? $iConf['altText'] : $address['name'];
             $iConf['titleText'] = !empty($iConf['titleText']) ? $iConf['titleText'] : $address['name'];
 
-            $markerArray['###IMAGE###'] = $lcObj->render($lcObj->getContentObject('IMAGE'), $iConf);
+            $markerArray['###IMAGE###'] = $lcObj->cObjGetSingle('IMAGE', $iConf);
         }
 
         // adds hook for processing of extra item markers


### PR DESCRIPTION
The Placeholder will not display on TYPO3 6.2.27.
This will be fix it.