### PR TITLE
Feature: Schema.org attributes

### DIFF
--- a/res/default_hcard.htm
+++ b/res/default_hcard.htm
@@ -38,7 +38,7 @@ Markers you can use:
 -->
 
 <!-- ###TEMPLATE_ADDRESS### beginn -->
-<address class="vcard" itemscope itemtype="http://schema.org/Person">
+<div class="vcard" itemscope itemtype="http://schema.org/Person">
 ###IMAGE###
 <!-- ###SUBPART_URL### begin -->
 ###FIRSTNAME### ###MIDDLENAME### ###LASTNAME###
@@ -52,7 +52,7 @@ Markers you can use:
 </div>
 <!-- ###SUBPART_ADR### end -->
 ###PHONE###
-</address>
+</div>
 <!-- ###TEMPLATE_ADDRESS### end -->
 
 </body>

--- a/res/default_hcard.htm
+++ b/res/default_hcard.htm
@@ -38,7 +38,7 @@ Markers you can use:
 -->
 
 <!-- ###TEMPLATE_ADDRESS### beginn -->
-<div class="vcard">
+<address class="vcard" itemscope itemtype="http://schema.org/Person">
 ###IMAGE###
 <!-- ###SUBPART_URL### begin -->
 ###FIRSTNAME### ###MIDDLENAME### ###LASTNAME###
@@ -46,13 +46,13 @@ Markers you can use:
 ###ORGANIZATION###
 ###EMAIL###
 <!-- ###SUBPART_ADR### begin -->
-<div class="adr">
+<div class="adr" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
 ###ADDRESS###
 ###CITY### ###REGION### ###ZIP### ###COUNTRY###
 </div>
 <!-- ###SUBPART_ADR### end -->
 ###PHONE###
-</div>
+</address>
 <!-- ###TEMPLATE_ADDRESS### end -->
 
 </body>

--- a/static/pi1/setup.txt
+++ b/static/pi1/setup.txt
@@ -23,74 +23,75 @@ plugin.tx_ttaddress_pi1 {
 		}
 
 		first_name {
-			innerWrap = <span class="fn">|
+			innerWrap = <span class="fn" item="name">|
 			innerWrap.if.isFalse.field = middle_name
-			innerWrap2 = <span class="given-name">|</span>
+			innerWrap2 = <span class="given-name" item="givenName">|</span>
 			innerWrap2.if.isTrue.field = middle_name
-			outerWrap = <span class="fn n">|
+			outerWrap = <span class="fn n" item="name">|
 			outerWrap.if.isTrue.field = middle_name
 		}
 
-		middle_name.wrap = <span class="additional-name">|</span>
+		middle_name.wrap = <span class="additional-name" item="
+additionalName">|</span>
 		middle_name.required = 1
 
 		last_name {
 			innerWrap = |</span>
 			innerWrap.if.isFalse.field = middle_name
-			innerWrap2 = <span class="family-name">|</span>
+			innerWrap2 = <span class="family-name" item="familyName">|</span>
 			innerWrap2.if.isTrue.field = middle_name
 			outerWrap = |</span>
 			outerWrap.if.isTrue.field = middle_name
 		}
 
 		organization {
-			wrap = <div class="org">|</div>
+			wrap = <div class="org" item="worksFor">|</div>
 			required = 1
 		}
 
 		email.typolink.parameter.field = email
-		email.typolink.ATagParams = class="email"
+		email.typolink.ATagParams = class="email" item="email"
 		email.required = 1
 
 		address {
-			wrap = <div class="street-address">|</div>
+			wrap = <div class="street-address" itemprop="streetAddress">|</div>
 			br =1
 			required = 1
 		}
 
 		city {
-			wrap = <span class="locality">|</span>
+			wrap = <span class="locality" itemprop="addressLocality">|</span>
 			required = 1
 			outerWrap = |,
 			outerWrap.if.isTrue.field = region
 		}
 
 		region {
-			wrap = <span class="region">|</span>
+			wrap = <span class="region" itemprop="addressRegion">|</span>
 			required = 1
 			outerWrap = |,
 			outerWrap.if.isTrue.field = zip
 		}
 
 		zip {
-			noTrimWrap = | <span class="postal-code">|</span>|
+			noTrimWrap = | <span class="postal-code" itemprop="postalCode">|</span>|
 			required = 1
 			outerWrap = , |
 			outerWrap.if.isFalse.field = region
 		}
 
 		country {
-			wrap = <span class="country-name">|</span>
+			wrap = <span class="country-name" item="addressCountry">|</span>
 			required = 1
 		}
 
-		phone.wrap = <div class="tel phone">|</div>
+		phone.wrap = <div class="tel phone" item="telephone">|</div>
 		phone.required = 1
 
 		mobile.wrap = <div class="tel mobile">|</div>
 		mobile.required = 1
 
-		fax.wrap = <div class="tel fax">|</div>
+		fax.wrap = <div class="tel fax" item="faxNumber">|</div>
 		fax.required = 1
 
 		subparts {
@@ -98,7 +99,7 @@ plugin.tx_ttaddress_pi1 {
 			url.typolink {
 				parameter.field = www
 				target =
-				ATagParams = class="url"
+				ATagParams = class="url" item="url"
 			}
 		}
 	}


### PR DESCRIPTION
I've added the corresponding [Schema.org](http://schema.org/Person) attributes to the vcard.
This helps structuring the information and improves indexing for search engines.
The resulting markup looks like the following:

```html
<address class="vcard" itemscope itemtype="http://schema.org/Person">
  <img src="path/to/image.jpg" alt="">

  <span class="fn" item="name">
    <span class="given-name" item="givenName">Firstname</span>
    <span class="additional-name" item="additionalName">Middlename</span>
    <span class="family-name" item="familyName">Lastname</span>
  </span>

  <div class="org" item="worksFor">Organization</div>
  <a href="mailto:info@mailaddress.com" class="email" item="email">info@mailaddress.com</a>

  <div class="adr" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
    <div class="street-address" itemprop="streetAddress">
      Streetname No
    </div>
    <span class="locality" itemprop="addressLocality">City</span>
    <span class="region" itemprop="addressRegion">Region</span>
    <span class="postal-code" itemprop="postalCode">Zip</span>
    <span class="country-name" item="addressCountry">Country</span>
  </div>
  <div class="tel phone" item="telephone">Phone</div>
</address>
```

![image](https://cloud.githubusercontent.com/assets/5244986/20017899/e8b10e2a-a2c5-11e6-84ec-602e74f87da1.png)
![image](https://cloud.githubusercontent.com/assets/5244986/20017905/f040a6c8-a2c5-11e6-92c0-ec6b8c08b855.png)
