### PR TITLE
[BUGFIX] Wrong language labels for recursive option

### DIFF
--- a/pi1/flexform.xml
+++ b/pi1/flexform.xml
@@ -139,23 +139,23 @@
 										<numIndex index="1"></numIndex>
 									</numIndex>
 									<numIndex index="1" type="array">
-										<numIndex index="0">LLL:EXT:cms/locallang_ttc.php:recursive.I.1</numIndex>
+										<numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.1</numIndex>
 										<numIndex index="1">1</numIndex>
 									</numIndex>
 									<numIndex index="2" type="array">
-										<numIndex index="0">LLL:EXT:cms/locallang_ttc.php:recursive.I.2</numIndex>
+										<numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.2</numIndex>
 										<numIndex index="1">2</numIndex>
 									</numIndex>
 									<numIndex index="3" type="array">
-										<numIndex index="0">LLL:EXT:cms/locallang_ttc.php:recursive.I.3</numIndex>
+										<numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.3</numIndex>
 										<numIndex index="1">3</numIndex>
 									</numIndex>
 									<numIndex index="4" type="array">
-										<numIndex index="0">LLL:EXT:cms/locallang_ttc.php:recursive.I.4</numIndex>
+										<numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.4</numIndex>
 										<numIndex index="1">4</numIndex>
 									</numIndex>
 									<numIndex index="5" type="array">
-										<numIndex index="0">LLL:EXT:cms/locallang_ttc.php:recursive.I.5</numIndex>
+										<numIndex index="0">LLL:EXT:cms/locallang_ttc.xlf:recursive.I.5</numIndex>
 										<numIndex index="1">250</numIndex>
 									</numIndex>
 								</items>


### PR DESCRIPTION
Fixes the language labels for the recursive option in flexform
to point to the correct language file.