### PR TITLE
[TASK] Usage of deprecated call to compat_version()

### DIFF
--- a/Configuration/TCA/tt_address.php
+++ b/Configuration/TCA/tt_address.php
@@ -1,7 +1,7 @@
 <?php
 $settings = \TYPO3\TtAddress\Utility\SettingsUtility::getSettings();
 
-$version7 = \TYPO3\CMS\Core\Utility\GeneralUtility::compat_version('7.0');
+$version7 = \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger('7.0');
 
 return array(
     'ctrl' => array(


### PR DESCRIPTION
GeneralUtility::compat_version has been deprecated with TYPO3 v8 and
removed with v9, use direct calls to
VersionNumberUtility::convertVersionNumberToInteger() instead, those
even work in v6.2