### PR TITLE
Typo3 9.x compatibility #67

### DIFF
--- a/Classes/Hooks/DataHandler/BackwardsCompatibilityNameFormat.php
+++ b/Classes/Hooks/DataHandler/BackwardsCompatibilityNameFormat.php
@@ -15,6 +15,8 @@ namespace TYPO3\TtAddress\Hooks\DataHandler;
  */
 
 use TYPO3\TtAddress\Utility\SettingsUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Class BackwardsCompatibilityNameFormat
@@ -69,12 +71,27 @@ class BackwardsCompatibilityNameFormat
      */
     protected function getFullRecord($uid)
     {
+        if (class_exists(ConnectionPool::class)) {
+            /** @var QueryBuilder $queryBuilder */
+            $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable('tt_address');
+            $queryBuilder->createNamedParameter($uid, \PDO::PARAM_INT, ':uid');
+
+            return $queryBuilder
+                ->select('*')
+                ->from('tt_address')
+                ->where(
+                    $queryBuilder->expr()->eq('uid', ':uid')
+                )
+                ->execute()
+                ->fetch();
+        }
+
         $row = $GLOBALS['TYPO3_DB']->exec_SELECTgetRows(
             '*',
             'tt_address',
             'uid = ' . $uid
         );
-
+        
         return $row[0];
     }
 }

--- a/Configuration/TCA/tt_address.php
+++ b/Configuration/TCA/tt_address.php
@@ -2,8 +2,9 @@
 $settings = \TYPO3\TtAddress\Utility\SettingsUtility::getSettings();
 
 $version8 = \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger('8.0');
+$version9 = \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) >= \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger('9.3');
 
-$generalLanguageFilePrefix = $version8 ? 'LLL:EXT:lang/Resources/Private/Language/' : 'LLL:EXT:lang/';
+$generalLanguageFilePrefix = $version9 ? 'LLL:EXT:core/Resources/Private/Language/' : ($version8 ? 'LLL:EXT:lang/Resources/Private/Language/' : 'LLL:EXT:lang/');
 
 return [
     'ctrl' => [

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,11 +20,11 @@ $EM_CONF[$_EXTKEY] = [
     'clearCacheOnLoad' => 1,
     'author' => 'tt_address Development Team',
     'author_email' => 'friendsof@typo3.org',
-    'version' => '4.0.0',
+    'version' => '4.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '7.6.0-8.9.99',
-            'php' => '5.5.0-7.1.99'
+            'typo3' => '7.6.0-9.9.99',
+            'php' => '5.5.0-7.2.99'
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
- Migrating from TYPO3_DB to doctrine-dbal in classes BackwardsCompatibilityNameFormat hook and ImageToFileReference updates.
- General language files moved from Ext:lang to Ext:core language resource in TYPO3 v9.3 update.