### PR TITLE
Enable exclude fields for plugin

### DIFF
--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -3,18 +3,14 @@
         <sDEF>
             <ROOT>
                 <TCEforms>
-                    <sheetTitle>
-                        LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sheet_selection
-                    </sheetTitle>
+                    <sheetTitle>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sheet_selection</sheetTitle>
                 </TCEforms>
                 <type>array</type>
                 <el>
                     <settings.singleRecords>
                         <TCEforms>
                             <exclude>1</exclude>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.single_records
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.single_records</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>
@@ -39,9 +35,7 @@
                     </settings.singleRecords>
                     <settings.groups>
                         <TCEforms>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.group_selection
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.group_selection</label>
                             <config>
                                 <type>select</type>
                                 <renderMode>tree</renderMode>
@@ -67,9 +61,7 @@
                     </settings.groups>
                     <settings.groupsCombination>
                         <TCEforms>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination</label>
                             <config>
                                 <type>select</type>
                                 <items type="array">
@@ -92,9 +84,7 @@
                     </settings.groupsCombination>
                     <settings.sortBy>
                         <TCEforms>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortBy
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortBy</label>
                             <config>
                                 <type>select</type>
                                 <items type="array">
@@ -110,22 +100,16 @@
                     </settings.sortBy>
                     <settings.sortOrder>
                         <TCEforms>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder</label>
                             <config>
                                 <type>select</type>
                                 <items type="array">
                                     <numIndex index="0" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder.ascending
-                                        </numIndex>
+                                        <numIndex index="0">LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder.ascending</numIndex>
                                         <numIndex index="1">ASC</numIndex>
                                     </numIndex>
                                     <numIndex index="1" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder.descending
-                                        </numIndex>
+                                        <numIndex index="0">LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder.descending</numIndex>
                                         <numIndex index="1">DESC</numIndex>
                                     </numIndex>
                                 </items>
@@ -199,17 +183,13 @@
         <sDISPLAY>
             <ROOT>
                 <TCEforms>
-                    <sheetTitle>
-                        LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sheet_display
-                    </sheetTitle>
+                    <sheetTitle>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sheet_display</sheetTitle>
                 </TCEforms>
                 <type>array</type>
                 <el>
                     <settings.displayMode>
                         <TCEforms>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode</label>
                             <config>
                                 <type>select</type>
                                 <renderType>selectSingle</renderType>
@@ -229,9 +209,7 @@
 
                     <settings.hidePagination>
                         <TCEforms>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.hidePagination
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.hidePagination</label>
                             <config>
                                 <type>check</type>
                             </config>
@@ -240,9 +218,7 @@
 
                     <settings.paginate.itemsPerPage>
                         <TCEforms>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.itemsPerPage
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.itemsPerPage</label>
                             <config>
                                 <type>input</type>
                                 <size>5</size>
@@ -254,9 +230,7 @@
 
                     <settings.singlePid>
                         <TCEforms>
-                            <label>
-                                LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.singlePid
-                            </label>
+                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.singlePid</label>
                             <config>
                                 <type>group</type>
                                 <internal_type>db</internal_type>

--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -37,6 +37,7 @@
 					</settings.singleRecords>
 					<settings.groups>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.group_selection
 							</label>
 							<config>
@@ -64,6 +65,7 @@
 					</settings.groups>
 					<settings.groupsCombination>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination</label>
 							<config>
 								<type>select</type>
@@ -87,6 +89,7 @@
 					</settings.groupsCombination>
 					<settings.sortBy>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortBy</label>
 							<config>
 								<type>select</type>
@@ -103,6 +106,7 @@
 					</settings.sortBy>
 					<settings.sortOrder>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder</label>
 							<config>
 								<type>select</type>
@@ -146,6 +150,7 @@
 					</settings.pages>
 					<settings.recursive>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.recursive</label>
 							<config>
 								<type>select</type>
@@ -205,6 +210,7 @@
 				<el>
 					<settings.displayMode>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode</label>
 							<config>
 								<type>select</type>
@@ -229,6 +235,7 @@
 
 					<settings.hidePagination>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.hidePagination
 							</label>
 							<config>
@@ -239,6 +246,7 @@
 
 					<settings.paginate.itemsPerPage>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.itemsPerPage</label>
 							<config>
 								<type>input</type>
@@ -251,6 +259,7 @@
 
 					<settings.singlePid>
 						<TCEforms>
+							<exclude>1</exclude>
 							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.singlePid</label>
 							<config>
 								<type>group</type>

--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -1,255 +1,276 @@
 <T3DataStructure>
-    <sheets>
-        <sDEF>
-            <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sheet_selection</sheetTitle>
-                </TCEforms>
-                <type>array</type>
-                <el>
-                    <settings.singleRecords>
-                        <TCEforms>
-                            <exclude>1</exclude>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.single_records</label>
-                            <config>
-                                <type>group</type>
-                                <internal_type>db</internal_type>
-                                <allowed>tt_address</allowed>
-                                <size>5</size>
-                                <maxitems>100</maxitems>
-                                <minitems>0</minitems>
-                                <autoSizeMax>10</autoSizeMax>
-                                <show_thumbs>1</show_thumbs>
-                                <wizards>
-                                    <suggest>
-                                        <type>suggest</type>
-                                    </suggest>
-                                </wizards>
-                                <suggestOptions>
-                                    <default>
-                                        <addWhere>AND tt_address.sys_language_uid IN (-1,0)</addWhere>
-                                    </default>
-                                </suggestOptions>
-                            </config>
-                        </TCEforms>
-                    </settings.singleRecords>
-                    <settings.groups>
-                        <TCEforms>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.group_selection</label>
-                            <config>
-                                <type>select</type>
-                                <renderMode>tree</renderMode>
-                                <treeView>1</treeView>
-                                <foreign_table>sys_category</foreign_table>
-                                <foreign_table_where>AND sys_category.sys_language_uid IN (-1, 0) ORDER BY
-                                    sys_category.sorting ASC
-                                </foreign_table_where>
-                                <size>5</size>
-                                <autoSizeMax>10</autoSizeMax>
-                                <minitems>0</minitems>
-                                <maxitems>20</maxitems>
-                                <treeConfig>
-                                    <parentField>parent</parentField>
-                                    <appearance>
-                                        <expandAll>1</expandAll>
-                                        <showHeader>1</showHeader>
-                                        <maxLevels>99</maxLevels>
-                                    </appearance>
-                                </treeConfig>
-                            </config>
-                        </TCEforms>
-                    </settings.groups>
-                    <settings.groupsCombination>
-                        <TCEforms>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination</label>
-                            <config>
-                                <type>select</type>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination.and
-                                        </numIndex>
-                                        <numIndex index="1">0</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">
-                                            LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination.or
-                                        </numIndex>
-                                        <numIndex index="1">1</numIndex>
-                                    </numIndex>
-                                </items>
-                                <default>0</default>
-                            </config>
-                        </TCEforms>
-                    </settings.groupsCombination>
-                    <settings.sortBy>
-                        <TCEforms>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortBy</label>
-                            <config>
-                                <type>select</type>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0"></numIndex>
-                                        <numIndex index="1">default</numIndex>
-                                    </numIndex>
-                                </items>
-                                <itemsProcFunc>FriendsOfTYPO3\TtAddress\Hooks\Tca\AddFieldsToSelector->main
-                                </itemsProcFunc>
-                            </config>
-                        </TCEforms>
-                    </settings.sortBy>
-                    <settings.sortOrder>
-                        <TCEforms>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder</label>
-                            <config>
-                                <type>select</type>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder.ascending</numIndex>
-                                        <numIndex index="1">ASC</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder.descending</numIndex>
-                                        <numIndex index="1">DESC</numIndex>
-                                    </numIndex>
-                                </items>
-                                <default>ASC</default>
-                            </config>
-                        </TCEforms>
-                    </settings.sortOrder>
-                    <settings.pages>
-                        <TCEforms>
-                            <exclude>1</exclude>
-                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
-                            <config>
-                                <type>group</type>
-                                <internal_type>db</internal_type>
-                                <allowed>pages</allowed>
-                                <size>3</size>
-                                <maxitems>22</maxitems>
-                                <minitems>0</minitems>
-                                <show_thumbs>1</show_thumbs>
-                                <wizards>
-                                    <suggest>
-                                        <type>suggest</type>
-                                    </suggest>
-                                </wizards>
-                            </config>
-                        </TCEforms>
-                    </settings.pages>
-                    <settings.recursive>
-                        <TCEforms>
-                            <label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.recursive</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <items type="array">
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.recursive.I.inherit</numIndex>
-                                        <numIndex index="1"></numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.0</numIndex>
-                                        <numIndex index="1">0</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.1</numIndex>
-                                        <numIndex index="1">1</numIndex>
-                                    </numIndex>
-                                    <numIndex index="4" type="array">
-                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.2</numIndex>
-                                        <numIndex index="1">2</numIndex>
-                                    </numIndex>
-                                    <numIndex index="5" type="array">
-                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.3</numIndex>
-                                        <numIndex index="1">3</numIndex>
-                                    </numIndex>
-                                    <numIndex index="6" type="array">
-                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.4</numIndex>
-                                        <numIndex index="1">4</numIndex>
-                                    </numIndex>
-                                    <numIndex index="7" type="array">
-                                        <numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.5</numIndex>
-                                        <numIndex index="1">250</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
-                    </settings.recursive>
-                </el>
-            </ROOT>
-        </sDEF>
+	<sheets>
+		<sDEF>
+			<ROOT>
+				<TCEforms>
+					<sheetTitle>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sheet_selection
+					</sheetTitle>
+				</TCEforms>
+				<type>array</type>
+				<el>
+					<settings.singleRecords>
+						<TCEforms>
+							<exclude>1</exclude>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.single_records
+							</label>
+							<config>
+								<type>group</type>
+								<internal_type>db</internal_type>
+								<allowed>tt_address</allowed>
+								<size>5</size>
+								<maxitems>100</maxitems>
+								<minitems>0</minitems>
+								<autoSizeMax>10</autoSizeMax>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+									<suggest>
+										<type>suggest</type>
+									</suggest>
+								</wizards>
+								<suggestOptions>
+									<default>
+										<addWhere>AND tt_address.sys_language_uid IN (-1,0)</addWhere>
+									</default>
+								</suggestOptions>
+							</config>
+						</TCEforms>
+					</settings.singleRecords>
+					<settings.groups>
+						<TCEforms>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.group_selection
+							</label>
+							<config>
+								<type>select</type>
+								<renderMode>tree</renderMode>
+								<treeView>1</treeView>
+								<foreign_table>sys_category</foreign_table>
+								<foreign_table_where>AND sys_category.sys_language_uid IN (-1, 0) ORDER BY
+									sys_category.sorting ASC
+								</foreign_table_where>
+								<size>5</size>
+								<autoSizeMax>10</autoSizeMax>
+								<minitems>0</minitems>
+								<maxitems>20</maxitems>
+								<treeConfig>
+									<parentField>parent</parentField>
+									<appearance>
+										<expandAll>1</expandAll>
+										<showHeader>1</showHeader>
+										<maxLevels>99</maxLevels>
+									</appearance>
+								</treeConfig>
+							</config>
+						</TCEforms>
+					</settings.groups>
+					<settings.groupsCombination>
+						<TCEforms>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination</label>
+							<config>
+								<type>select</type>
+								<items type="array">
+									<numIndex index="0" type="array">
+										<numIndex index="0">
+											LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination.and
+										</numIndex>
+										<numIndex index="1">0</numIndex>
+									</numIndex>
+									<numIndex index="1" type="array">
+										<numIndex index="0">
+											LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.combination.or
+										</numIndex>
+										<numIndex index="1">1</numIndex>
+									</numIndex>
+								</items>
+								<default>0</default>
+							</config>
+						</TCEforms>
+					</settings.groupsCombination>
+					<settings.sortBy>
+						<TCEforms>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortBy</label>
+							<config>
+								<type>select</type>
+								<items type="array">
+									<numIndex index="0" type="array">
+										<numIndex index="0"></numIndex>
+										<numIndex index="1">default</numIndex>
+									</numIndex>
+								</items>
+								<itemsProcFunc>FriendsOfTYPO3\TtAddress\Hooks\Tca\AddFieldsToSelector->main
+								</itemsProcFunc>
+							</config>
+						</TCEforms>
+					</settings.sortBy>
+					<settings.sortOrder>
+						<TCEforms>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder</label>
+							<config>
+								<type>select</type>
+								<items type="array">
+									<numIndex index="0" type="array">
+										<numIndex index="0">
+											LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder.ascending
+										</numIndex>
+										<numIndex index="1">ASC</numIndex>
+									</numIndex>
+									<numIndex index="1" type="array">
+										<numIndex index="0">
+											LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sortOrder.descending
+										</numIndex>
+										<numIndex index="1">DESC</numIndex>
+									</numIndex>
+								</items>
+								<default>ASC</default>
+							</config>
+						</TCEforms>
+					</settings.sortOrder>
+					<settings.pages>
+						<TCEforms>
+							<exclude>1</exclude>
+							<label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.startingpoint</label>
+							<config>
+								<type>group</type>
+								<internal_type>db</internal_type>
+								<allowed>pages</allowed>
+								<size>3</size>
+								<maxitems>22</maxitems>
+								<minitems>0</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+									<suggest>
+										<type>suggest</type>
+									</suggest>
+								</wizards>
+							</config>
+						</TCEforms>
+					</settings.pages>
+					<settings.recursive>
+						<TCEforms>
+							<label>LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.recursive</label>
+							<config>
+								<type>select</type>
+								<renderType>selectSingle</renderType>
+								<items type="array">
+									<numIndex index="1" type="array">
+										<numIndex index="0">
+											LLL:EXT:news/Resources/Private/Language/locallang_be.xlf:flexforms_general.recursive.I.inherit
+										</numIndex>
+										<numIndex index="1"></numIndex>
+									</numIndex>
+									<numIndex index="2" type="array">
+										<numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.0
+										</numIndex>
+										<numIndex index="1">0</numIndex>
+									</numIndex>
+									<numIndex index="3" type="array">
+										<numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.1
+										</numIndex>
+										<numIndex index="1">1</numIndex>
+									</numIndex>
+									<numIndex index="4" type="array">
+										<numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.2
+										</numIndex>
+										<numIndex index="1">2</numIndex>
+									</numIndex>
+									<numIndex index="5" type="array">
+										<numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.3
+										</numIndex>
+										<numIndex index="1">3</numIndex>
+									</numIndex>
+									<numIndex index="6" type="array">
+										<numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.4
+										</numIndex>
+										<numIndex index="1">4</numIndex>
+									</numIndex>
+									<numIndex index="7" type="array">
+										<numIndex index="0">LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:recursive.I.5
+										</numIndex>
+										<numIndex index="1">250</numIndex>
+									</numIndex>
+								</items>
+							</config>
+						</TCEforms>
+					</settings.recursive>
+				</el>
+			</ROOT>
+		</sDEF>
 
-        <sDISPLAY>
-            <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sheet_display</sheetTitle>
-                </TCEforms>
-                <type>array</type>
-                <el>
-                    <settings.displayMode>
-                        <TCEforms>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode.listView</numIndex>
-                                        <numIndex index="1">list</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode.singleView</numIndex>
-                                        <numIndex index="1">single</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
-                    </settings.displayMode>
+		<sDISPLAY>
+			<ROOT>
+				<TCEforms>
+					<sheetTitle>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.sheet_display
+					</sheetTitle>
+				</TCEforms>
+				<type>array</type>
+				<el>
+					<settings.displayMode>
+						<TCEforms>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode</label>
+							<config>
+								<type>select</type>
+								<renderType>selectSingle</renderType>
+								<items type="array">
+									<numIndex index="0" type="array">
+										<numIndex index="0">
+											LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode.listView
+										</numIndex>
+										<numIndex index="1">list</numIndex>
+									</numIndex>
+									<numIndex index="1" type="array">
+										<numIndex index="0">
+											LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.displayMode.singleView
+										</numIndex>
+										<numIndex index="1">single</numIndex>
+									</numIndex>
+								</items>
+							</config>
+						</TCEforms>
+					</settings.displayMode>
 
-                    <settings.hidePagination>
-                        <TCEforms>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.hidePagination</label>
-                            <config>
-                                <type>check</type>
-                            </config>
-                        </TCEforms>
-                    </settings.hidePagination>
+					<settings.hidePagination>
+						<TCEforms>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.hidePagination
+							</label>
+							<config>
+								<type>check</type>
+							</config>
+						</TCEforms>
+					</settings.hidePagination>
 
-                    <settings.paginate.itemsPerPage>
-                        <TCEforms>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.itemsPerPage</label>
-                            <config>
-                                <type>input</type>
-                                <size>5</size>
-                                <max>5</max>
-                                <eval>trim, intval</eval>
-                            </config>
-                        </TCEforms>
-                    </settings.paginate.itemsPerPage>
+					<settings.paginate.itemsPerPage>
+						<TCEforms>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.itemsPerPage</label>
+							<config>
+								<type>input</type>
+								<size>5</size>
+								<max>5</max>
+								<eval>trim, intval</eval>
+							</config>
+						</TCEforms>
+					</settings.paginate.itemsPerPage>
 
-                    <settings.singlePid>
-                        <TCEforms>
-                            <label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.singlePid</label>
-                            <config>
-                                <type>group</type>
-                                <internal_type>db</internal_type>
-                                <allowed>pages</allowed>
-                                <size>1</size>
-                                <maxitems>1</maxitems>
-                                <minitems>0</minitems>
-                                <show_thumbs>1</show_thumbs>
-                                <wizards>
-                                    <suggest>
-                                        <type>suggest</type>
-                                    </suggest>
-                                </wizards>
-                            </config>
-                        </TCEforms>
-                    </settings.singlePid>
-                </el>
-            </ROOT>
-        </sDISPLAY>
+					<settings.singlePid>
+						<TCEforms>
+							<label>LLL:EXT:tt_address/Resources/Private/Language/ff/locallang_ff.xlf:pi1_flexform.singlePid</label>
+							<config>
+								<type>group</type>
+								<internal_type>db</internal_type>
+								<allowed>pages</allowed>
+								<size>1</size>
+								<maxitems>1</maxitems>
+								<minitems>0</minitems>
+								<show_thumbs>1</show_thumbs>
+								<wizards>
+									<suggest>
+										<type>suggest</type>
+									</suggest>
+								</wizards>
+							</config>
+						</TCEforms>
+					</settings.singlePid>
+				</el>
+			</ROOT>
+		</sDISPLAY>
 
-    </sheets>
+	</sheets>
 </T3DataStructure>


### PR DESCRIPTION
* [Bugfix] Linebreaks are not allowed in XML. Label was not shown in group-settings
* [WIP] Change spaces to tabs in XML
* [TASK] Make all (FlexForm) fields selectable by exclude list