### PR TITLE
[BUGFIX] Overwriting of storage pid from flexform

### DIFF
--- a/Classes/Controller/LegacyPluginController.php
+++ b/Classes/Controller/LegacyPluginController.php
@@ -152,7 +152,7 @@ class LegacyPluginController extends AbstractPlugin
         $this->conf['sortOrder'] = strtoupper($sortOrder) === 'DESC' ? SORT_DESC : SORT_ASC;
 
         // overwrite TS pidList if set in flexform
-        $pages = !empty($this->ffData['pages']) ?:
+        $pages = !empty($this->ffData['pages']) ? $this->ffData['pages'] :
             trim($this->cObj->stdWrap($this->conf['pidList'], $this->conf['pidList.']));
         $pages = $pages ?
             implode(GeneralUtility::intExplode(',', $pages), ',') :


### PR DESCRIPTION
The elvis operator :? leads to TRUE resulting in pid 1 and not
to the value of $this->ffData['pages']

Closes: #138