### PR TITLE
Allow hyphen for phone number extension. See https://en.wikipedia.org…

### DIFF
--- a/Classes/Evaluation/TelephoneEvaluation.php
+++ b/Classes/Evaluation/TelephoneEvaluation.php
@@ -24,7 +24,7 @@ class TelephoneEvaluation
     public function returnFieldJS()
     {
         return '
-         return value.replace(/[^\d\+\s]/g, "");
+         return value.replace(/[^\d\+\s\-]/g, "");
       ';
     }
 
@@ -52,7 +52,7 @@ class TelephoneEvaluation
 
     private function evaluate(string $in)
     {
-        $data = preg_replace("/[^\d\+\s]/", '', $in);
+        $data = preg_replace("/[^\d\+\s\-]/", '', $in);
         return trim($data);
     }
 }


### PR DESCRIPTION
Sometimes customers use phone number extensions with hyphens to visualize the difference to the main number. 
See: https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers#Germany