### PR TITLE
[TASK] Minor bugfiles and improvements

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -18,7 +18,7 @@ plugin.tx_ttaddress {
 
     settings {
         ## Override settings if empty in flexform
-        overrideFlexformSettingsIfEmpty = paginate.itemsPerPage, singlePid, recursive
+        overrideFlexformSettingsIfEmpty = paginate.itemsPerPage, singlePid, pages, recursive
 
         detail {
             ## Set your lightbox here. The address records UID is appended, see fluid template

--- a/Resources/Private/Partials/ListItem.html
+++ b/Resources/Private/Partials/ListItem.html
@@ -3,7 +3,7 @@
     <div class="row">
         <div class="col-md-2 addressImage">
             <f:link.action action="show" arguments="{address : address}"
-                           title="{address.firstTitle} {address.firstName} {address.middleName} {address.lastName}"
+                           title="{address.title} {address.firstName} {address.middleName} {address.lastName}"
                            pageUid="{settings.singlePid}">
                 <f:if condition="{address.image}">
                     <f:media file="{address.firstImage}" width="400" class="img-fluid img-thumbnail rounded"
@@ -23,7 +23,7 @@
 
             <f:if condition="{settings.singlePid}">
                 <f:link.action action="show" arguments="{address : address}"
-                               title="{address.firstTitle} {address.firstName} {address.middleName} {address.lastName}"
+                               title="{address.title} {address.firstName} {address.middleName} {address.lastName}"
                                pageUid="{settings.singlePid}" class="btn btn-default">{f:translate(key:'more')}
                 </f:link.action>
             </f:if>


### PR DESCRIPTION
[TASK ]Always include "pages" in overrideFlexformSettingsIfEmpty

In order to override the storagePage by TypoScript, the setting
"pages" must be included in overrideFlexformSettingsIfEmpty. This
setting should be provided by default.

[BUGFIX] Fixed missing title attribute in links to detail page