### PR TITLE
[TASK] Skip inconsistent flexform in migration task

### DIFF
--- a/Classes/Updates/MigrateLegacyPlugin.php
+++ b/Classes/Updates/MigrateLegacyPlugin.php
@@ -95,6 +95,14 @@ class MigrateLegacyPlugin extends AbstractUpdate
             $flexformArray = GeneralUtility::xml2array($record['pi_flexform']);
             $newFlexformArray = $flexformArray;
 
+            // Skip migration of record, when flexform is inconsistent
+            if (!isset($flexformArray['data']) ||
+                !isset($flexformArray['data']['sDISPLAY']) ||
+                !isset($flexformArray['data']['sDEF'])
+            ) {
+                continue;
+            }
+
             foreach ($flexformArray['data']['sDEF']['lDEF'] as $key => $value) {
                 if (isset($this->configurationKeyMap[$key])) {
                     $newFlexformArray['data']['sDEF']['lDEF'][$this->configurationKeyMap[$key]] = $value;

--- a/Tests/Functional/Fixtures/tt_content.xml
+++ b/Tests/Functional/Fixtures/tt_content.xml
@@ -91,5 +91,18 @@
             </T3FlexForms>
            ]]>
         </pi_flexform>
+    </tt_content>    <tt_content>
+        <uid>3</uid>
+        <pid>1</pid>
+        <list_type>tt_address_pi1</list_type>
+        <pi_flexform>
+            <![CDATA[
+            <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+            <T3FlexForms>
+                <data>
+                </data>
+            </T3FlexForms>
+           ]]>
+        </pi_flexform>
     </tt_content>
 </dataset>


### PR DESCRIPTION
When running the migration task it has to be ensured, only flexform
with consistent end expected keys in the array will be migrated.