### PR TITLE
[TASK] Make building and room field available in access control options

### DIFF
--- a/Configuration/TCA/tt_address.php
+++ b/Configuration/TCA/tt_address.php
@@ -213,6 +213,7 @@ return [
             ]
         ],
         'building' => [
+            'exclude' => true,
             'label' => 'LLL:EXT:tt_address/Resources/Private/Language/locallang_db.xlf:tt_address.building',
             'config' => [
                 'type' => 'input',
@@ -225,6 +226,7 @@ return [
             ]
         ],
         'room' => [
+            'exclude' => true,
             'label' => 'LLL:EXT:tt_address/Resources/Private/Language/locallang_db.xlf:tt_address.room',
             'config' => [
                 'type' => 'input',


### PR DESCRIPTION
Hide building and room fields by default for users to make them available in access control options.