### PR TITLE
extend TS setup for ease of use

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -18,8 +18,29 @@ plugin.tx_ttaddress {
 
     settings {
         ## Override settings if empty in flexform
-        overrideFlexformSettingsIfEmpty = paginate.itemsPerPage, singlePid, pages, recursive, hidePagination
+        overrideFlexformSettingsIfEmpty = paginate.itemsPerPage, singlePid, pages, recursive, hidePagination, sortBy, sortOrder, groupsCombination
 
+        # comma separated list of page IDs containing address records
+        pages = 
+        
+        # recursion level: same_page_only=0
+        recursive = 
+        
+        # display mode: List=0, Detail=1, Map=2
+        displayMode = 
+        
+        # groups combination: AND=0, OR=1
+        groupsCombination = 
+        
+        # sort by field
+        sortBy = 
+        
+        # order: ASC, DESC
+        sortOrder = 
+        
+        # page ID of single view
+        singlePid = 
+        
         detail {
             ## Set your lightbox here. The address records UID is appended, see fluid template
             imageClass = lightbox lightbox_
@@ -44,6 +65,9 @@ plugin.tx_ttaddress {
                     size = 500x400
                 }
             }
+            
+            # single view page ID, used in rendering section of partial Maps.html to show link to single view if set
+            singlePid = 
         }
 
         paginate {


### PR DESCRIPTION
added some more setup variables to make it more easy for admins using the backend typoscript browser or analyser. 
added a new setup variable settings.map.singlePid to be able to show a link to the single view in the map info bubble; please see proposal in rendering section of partial Maps.html and consider publishing it. 
Settings displayMode, groupsCombination, sortBy, sortOrder are not working yet due to having default values in plugin.
Would you consider to change the default values of these fields in the plugin' selectors to something labeled like 'defined by typoscript'?
This way administrators would have the possiblity to set global defaults for plugins by typoscript. 
Setting overrideFlexformSettingsIfEmpty can be extended by the fields displayMode, groupsCombination, sortBy, sortOrder.