### PR TITLE
Feature/german umlaut fix

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -71,6 +71,13 @@ class AddressController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
             $addresses = $this->addressRepository->findByDemand($demand);
         }
 
+        if (GeneralUtility::makeInstance(Settings::class)->getTreatGermanUmlautsAsLatinCharacters()) {
+            $addresses = $addresses->toArray();
+            usort($addresses, function($a, $b) {
+                return $this->convertStringToLatin($a->getLastName()) > $this->convertStringToLatin($b->getLastName());
+            });
+        }
+
         $this->view->assignMultiple([
             'demand' => $demand,
             'addresses' => $addresses
@@ -79,6 +86,17 @@ class AddressController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
         CacheUtility::addCacheTagsByAddressRecords(
             $addresses instanceof QueryResultInterface ? $addresses->toArray() : $addresses
         );
+    }
+
+    /**
+     * Switch out all german umlaut characters with their expanded form
+     *
+     * @param string $string
+     * @return string
+     */
+    protected function convertStringToLatin(string $string): string
+    {
+        return str_replace(['ä', 'ü', 'ö', 'Ä', 'Ü', 'Ö', 'ß'], ['ae', 'ue', 'oe', 'Ae', 'Ue', 'Oe', 'ss'], $string);
     }
 
     /**

--- a/Classes/Domain/Model/Dto/Settings.php
+++ b/Classes/Domain/Model/Dto/Settings.php
@@ -33,6 +33,9 @@ class Settings implements SingletonInterface
     /** @var string */
     protected $telephoneValidationPatternForJs = '/[^\d\+\s\-]/g';
 
+    /** @var bool */
+    protected $treatGermanUmlautsAsLatinCharacters = false;
+
     /**
      */
     public function __construct()
@@ -44,6 +47,7 @@ class Settings implements SingletonInterface
             $this->storeBackwardsCompatName = (bool)$settings['storeBackwardsCompatName'];
             $this->readOnlyNameField = (bool)$settings['readOnlyNameField'];
             $this->activatePiBase = (bool)$settings['activatePiBase'];
+            $this->treatGermanUmlautsAsLatinCharacters = (bool)$settings['treatGermanUmlautsAsLatinCharacters'];
 
             if ($settings['telephoneValidationPatternForPhp']) {
                 $this->telephoneValidationPatternForPhp = (string)$settings['telephoneValidationPatternForPhp'];
@@ -100,5 +104,13 @@ class Settings implements SingletonInterface
     public function getTelephoneValidationPatternForJs(): string
     {
         return $this->telephoneValidationPatternForJs;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getTreatGermanUmlautsAsLatinCharacters(): bool
+    {
+        return $this->treatGermanUmlautsAsLatinCharacters;
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -15,3 +15,6 @@ telephoneValidationPatternForPhp = /[^\d\+\s\-]/
 
 # cat=backend; type=text; label=Pattern for validation telephone number in TCA with JS
 telephoneValidationPatternForJs = /[^\d\+\s\-]/g
+
+  # cat=basic; type=boolean; label=Treat umlauts as latin characters for sorting (e.g. Ã„ = Ae)
+treatGermanUmlautsAsLatinCharacters = 0


### PR DESCRIPTION
This fork adds a setting in the extension configuration that makes tt_address handle german umlaut characters as their expanded forms (i.e. Ä => Ae, ö = oe) when sorting in list view.