### PR TITLE
[BUGFIX] Load map also if scripts are loaded async

### DIFF
--- a/Resources/Public/JavaScript/Frontend/Leaflet.js
+++ b/Resources/Public/JavaScript/Frontend/Leaflet.js
@@ -35,7 +35,7 @@ function ttAddressLeaflet() {
     return obj;
 }
 
-document.addEventListener("DOMContentLoaded", function () {
+function ttAddressOnload() {
     var ttAddressMapInstance = ttAddressLeaflet();
     ttAddressMapInstance.run();
 
@@ -47,5 +47,16 @@ document.addEventListener("DOMContentLoaded", function () {
         var element = event.target;
         ttAddressMapInstance.openMarker(parseInt(element.getAttribute('data-iteration-id')));
     }, false);
+}
 
-});
+/** event listener on DOMContentLoaded does not work with scripts which are loaded async.
+  * With TYPO3 this could e.g. happen with EXT:scriptmerger
+  * Thus we listen only if document.readyState is loading, otherwise we can already fire as DOM is loaded already.
+ **/
+if (document.readyState === 'loading') {
+    document.addEventListener("DOMContentLoaded", function () {
+        ttAddressOnload();
+    });
+} else {
+    ttAddressOnload();
+}


### PR DESCRIPTION
Event listener on DOMContentLoaded does not work with scripts which are loaded async.
With TYPO3 this could e.g. happen with EXT:scriptmerger
Thus we listen only if document.readyState is loading, otherwise we can already fire as DOM is loaded already.