### PR TITLE
Fix TCA locallang for field sys_language_uid

### DIFF
--- a/Configuration/TCA/tt_address.php
+++ b/Configuration/TCA/tt_address.php
@@ -128,14 +128,14 @@ return [
         ],
         'sys_language_uid' => [
             'exclude' => true,
-            'label' => 'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.language',
+            'label' => $generalLanguageFilePrefix . 'locallang_general.xlf:LGL.language',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'special' => 'languages',
                 'items' => [
                     [
-                        'LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf:LGL.allLanguages',
+                        $generalLanguageFilePrefix . 'locallang_general.xlf:LGL.allLanguages',
                         -1,
                         'flags-multiple'
                     ],


### PR DESCRIPTION
Use TYPO3 version switch for field names locallang of field sys_language_uid.
#304