### PR TITLE
Multiple Whitespaces in Field Name if middle_name is empty

### DIFF
--- a/Classes/Hooks/DataHandler/BackwardsCompatibilityNameFormat.php
+++ b/Classes/Hooks/DataHandler/BackwardsCompatibilityNameFormat.php
@@ -44,12 +44,12 @@ class BackwardsCompatibilityNameFormat
 
                 $newRecord = array_merge($address, $fieldArray);
 
-                $combinedName = trim(sprintf(
+                $combinedName = preg_replace('/\s+/', ' ', trim(sprintf(
                     $this->settings->getBackwardsCompatFormat(),
                     $newRecord['first_name'],
                     $newRecord['middle_name'],
                     $newRecord['last_name']
-                ));
+                )));
 
                 if (!empty($combinedName)) {
                     $fieldArray['name'] = $combinedName;

--- a/Configuration/TCA/tt_address.php
+++ b/Configuration/TCA/tt_address.php
@@ -368,7 +368,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'size' => 20,
-                'eval' => 'email',
+                'eval' => 'trim,email',
                 'max' => 255,
                 'softref' => 'email',
                 'behaviour' => [


### PR DESCRIPTION
There's a problem with whitespaces if you wanna have middle_name in the field "name".
backwardsCompatFormat = %1$s %2$s %3$s
Works perfectly if there's a middle_name, but shows two spaces if it's empty.

That's my idea to solve that. ;)

PS: don't find a way to hide the other change that's already sent (trim of email in tca) by a pull request. guess I should have created a new copy.