### PR TITLE
[FEATURE] Provide stdWrap-functionality for TypoScript-settings

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -116,6 +116,21 @@ class AddressController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControll
             $originalSettings[$property] = $tsSettings['settings'][$property];
         }
 
+        // Use stdWrap for given defined settings
+        if (isset($originalSettings['useStdWrap']) && !empty($originalSettings['useStdWrap'])) {
+            $typoScriptService = GeneralUtility::makeInstance(TypoScriptService::class);
+            $typoScriptArray = $typoScriptService->convertPlainArrayToTypoScriptArray($originalSettings);
+            $stdWrapProperties = GeneralUtility::trimExplode(',', $originalSettings['useStdWrap'], true);
+            foreach ($stdWrapProperties as $key) {
+                if (is_array($typoScriptArray[$key . '.'])) {
+                    $originalSettings[$key] = $this->configurationManager->getContentObject()->stdWrap(
+                        $typoScriptArray[$key], 
+                        $typoScriptArray[$key . '.']
+                    );
+                }
+            }
+        }
+
         // start override
         if (isset($tsSettings['settings']['overrideFlexformSettingsIfEmpty'])) {
             $typoScriptUtility = GeneralUtility::makeInstance(TypoScript::class);


### PR DESCRIPTION
An additional setting useStdWrap is added with a list of fields
for which stdWrap-functionality should be applied.
This implementation is adapted from EXT:tt_news.

Resolves: #130