### PR TITLE
[TASK] Remove unnecessary limit

### DIFF
--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -18,7 +18,6 @@
                                 <internal_type>db</internal_type>
                                 <allowed>tt_address</allowed>
                                 <size>5</size>
-                                <maxitems>100</maxitems>
                                 <minitems>0</minitems>
                                 <autoSizeMax>10</autoSizeMax>
                                 <show_thumbs>1</show_thumbs>
@@ -51,7 +50,6 @@
                                 <size>5</size>
                                 <autoSizeMax>10</autoSizeMax>
                                 <minitems>0</minitems>
-                                <maxitems>20</maxitems>
                                 <treeConfig>
                                     <parentField>parent</parentField>
                                     <appearance>
@@ -156,7 +154,6 @@
                                 <internal_type>db</internal_type>
                                 <allowed>pages</allowed>
                                 <size>3</size>
-                                <maxitems>22</maxitems>
                                 <minitems>0</minitems>
                                 <show_thumbs>1</show_thumbs>
                                 <wizards>


### PR DESCRIPTION
Currently it's not possible to have more than 20 selected categories. The limit is unnecessary and therefore removed also for singleRecords and pages.