### PR TITLE
[TASK] Remove show_thumbs in Flexform

### DIFF
--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -20,7 +20,6 @@
                                 <size>5</size>
                                 <minitems>0</minitems>
                                 <autoSizeMax>10</autoSizeMax>
-                                <show_thumbs>1</show_thumbs>
                                 <wizards>
                                     <suggest>
                                         <type>suggest</type>
@@ -155,7 +154,6 @@
                                 <allowed>pages</allowed>
                                 <size>3</size>
                                 <minitems>0</minitems>
-                                <show_thumbs>1</show_thumbs>
                                 <wizards>
                                     <suggest>
                                         <type>suggest</type>
@@ -298,7 +296,6 @@
                                 <size>1</size>
                                 <maxitems>1</maxitems>
                                 <minitems>0</minitems>
-                                <show_thumbs>1</show_thumbs>
                                 <wizards>
                                     <suggest>
                                         <type>suggest</type>


### PR DESCRIPTION
The property show_thumbs for type=group is obsolete and
has been dropped from TCA in TYPO3 8.6.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.6/Deprecation-79440-TcaChanges.html