### PR TITLE
[BUGFIX] Set proper size of flexform settings.groups

### DIFF
--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -46,8 +46,7 @@
                                 <foreign_table_where>AND sys_category.sys_language_uid IN (-1, 0) ORDER BY
                                     sys_category.sorting ASC
                                 </foreign_table_where>
-                                <size>5</size>
-                                <autoSizeMax>10</autoSizeMax>
+                                <size>10</size>
                                 <minitems>0</minitems>
                                 <treeConfig>
                                     <parentField>parent</parentField>


### PR DESCRIPTION
The option `[config][autoSizeMax]` have no influence on the rendering of FormEngine select field configured with `'renderType' => 'selectTree'` anymore.
The option `autosizemax` has been dropped as the `size` can be used as maximum height.
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.3/Breaking-77081-RemovedTCASelectTreeOptions.html