### PR TITLE
Compatibility with Apache 2.4.x

### DIFF
--- a/Resources/Private/.htaccess
+++ b/Resources/Private/.htaccess
@@ -1,1 +1,10 @@
-deny from all
+# Apache < 2.3
+<IfModule !mod_authz_core.c>
+	Order allow,deny
+	Deny from all
+</IfModule>
+
+# Apache >= 2.3
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>


### PR DESCRIPTION
Resolves: #354

The current code in .htaccess works for Apache 2.2.x or with the compat-extension in 2.4.x. Clean this up.