### PR TITLE
Enhance List.xml Flexform

### DIFF
--- a/Configuration/FlexForms/List.xml
+++ b/Configuration/FlexForms/List.xml
@@ -279,7 +279,10 @@
                                 <type>input</type>
                                 <size>5</size>
                                 <max>5</max>
-                                <eval>trim, intval</eval>
+                                <range>
+                                    <lower>1</lower>
+                                </range>
+                                <eval>trim,int</eval>
                             </config>
                         </TCEforms>
                     </settings.paginate.itemsPerPage>


### PR DESCRIPTION
- Add range to from 1 to n to flexform settings.paginate.itemsPerPage (max value should be 99999 because size of field is 5).
- Change eval in settings.paginate.itemsPerPage from "trim,intval" to "trim,int" to get number evaluation in BE form.