### PR TITLE
[BUGFIX] Ignore newPagination setting for TYPO3 11

### DIFF
--- a/Classes/Domain/Model/Dto/Settings.php
+++ b/Classes/Domain/Model/Dto/Settings.php
@@ -10,6 +10,7 @@ namespace FriendsOfTYPO3\TtAddress\Domain\Model\Dto;
  * LICENSE.txt file that was distributed with this source code.
  */
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -65,7 +66,7 @@ class Settings
      */
     public function getNewPagination(): bool
     {
-        return $this->newPagination;
+        return $this->newPagination || GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 11;
     }
 
     protected function getSettings(): array

--- a/Configuration/TCA/Overrides/tt_address.php
+++ b/Configuration/TCA/Overrides/tt_address.php
@@ -1,5 +1,14 @@
 <?php
 defined('TYPO3_MODE') or die();
 
-// Enable language synchronisation for the category field
-$GLOBALS['TCA']['tt_address']['columns']['categories']['config']['behaviour']['allowLanguageSynchronization'] = true;
+call_user_func(static function () {
+    // Enable language synchronisation for the category field
+    $GLOBALS['TCA']['tt_address']['columns']['categories']['config']['behaviour']['allowLanguageSynchronization'] = true;
+
+    $versionInformation = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
+    if ($versionInformation->getMajorVersion() === 11) {
+        $GLOBALS['TCA']['tt_address']['columns']['sys_language_uid']['config'] = [
+            'type' => 'language'
+        ];
+    }
+});

--- a/Tests/Unit/Controller/AddressControllerTest.php
+++ b/Tests/Unit/Controller/AddressControllerTest.php
@@ -269,7 +269,7 @@ class AddressControllerTest extends BaseTestCase
             'addresses' => ['dummy return single']
         ];
 
-        $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple'], [], '', false);
+        $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple', 'assign'], [], '', false);
         $mockedView->expects($this->once())->method('assignMultiple')->with($assignments);
 
         $mockedRequest = $this->getAccessibleMock(Request::class, ['hasArgument', 'getArgument'], [], '', false);
@@ -306,7 +306,7 @@ class AddressControllerTest extends BaseTestCase
 
         $mockedRequest = $this->getAccessibleMock(Request::class, ['hasArgument', 'getArgument'], [], '', false);
 
-        $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple'], [], '', false);
+        $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple', 'assign'], [], '', false);
         $mockedView->expects($this->once())->method('assignMultiple')->with($assignments);
 
         $subject = $this->getAccessibleMock(AddressController::class, ['createDemandFromSettings'], [], '', false);
@@ -353,7 +353,7 @@ class AddressControllerTest extends BaseTestCase
 
         $mockedRepository = $this->getAccessibleMock(AddressRepository::class, ['getAddressesByCustomSorting', 'findByDemand'], [], '', false);
         $mockedRepository->expects($this->any())->method('findByDemand')->willReturn([]);
-        $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple'], [], '', false);
+        $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple', 'assign'], [], '', false);
         $mockedView->expects($this->once())->method('assignMultiple');
         $subject = $this->getAccessibleMock(AddressController::class, ['overrideDemand', 'createDemandFromSettings'], [], '', false);
         $subject->_set('extensionConfiguration', $this->getMockedSettings());

--- a/Tests/Unit/Controller/AddressControllerTest.php
+++ b/Tests/Unit/Controller/AddressControllerTest.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Mvc\Request;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -271,10 +272,15 @@ class AddressControllerTest extends BaseTestCase
         $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple'], [], '', false);
         $mockedView->expects($this->once())->method('assignMultiple')->with($assignments);
 
+        $mockedRequest = $this->getAccessibleMock(Request::class, ['hasArgument', 'getArgument'], [], '', false);
+        $mockedRequest->expects($this->once())->method('hasArgument')->with('currentPage')->willReturn(true);
+        $mockedRequest->expects($this->once())->method('getArgument')->with('currentPage')->willReturn(2);
+
         $subject = $this->getAccessibleMock(AddressController::class, ['createDemandFromSettings'], [], '', false);
         $subject->expects($this->once())->method('createDemandFromSettings')->willReturn($demand);
         $subject->_set('settings', $settings);
         $subject->_set('view', $mockedView);
+        $subject->_set('request', $mockedRequest);
         $subject->_set('addressRepository', $mockedRepository);
         $subject->_set('extensionConfiguration', $this->getMockedSettings());
 
@@ -300,6 +306,10 @@ class AddressControllerTest extends BaseTestCase
             'addresses' => ['dummy return']
         ];
 
+        $mockedRequest = $this->getAccessibleMock(Request::class, ['hasArgument', 'getArgument'], [], '', false);
+        $mockedRequest->expects($this->once())->method('hasArgument')->with('currentPage')->willReturn(true);
+        $mockedRequest->expects($this->once())->method('getArgument')->with('currentPage')->willReturn(2);
+
         $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple'], [], '', false);
         $mockedView->expects($this->once())->method('assignMultiple')->with($assignments);
 
@@ -307,6 +317,7 @@ class AddressControllerTest extends BaseTestCase
         $subject->expects($this->once())->method('createDemandFromSettings')->willReturn($demand);
         $subject->_set('settings', $settings);
         $subject->_set('view', $mockedView);
+        $subject->_set('request', $mockedRequest);
         $subject->_set('addressRepository', $mockedRepository);
         $subject->_set('extensionConfiguration', $this->getMockedSettings());
 
@@ -342,6 +353,10 @@ class AddressControllerTest extends BaseTestCase
      */
     public function overrideDemandMethodIsCalledIfEnabled()
     {
+        $mockedRequest = $this->getAccessibleMock(Request::class, ['hasArgument', 'getArgument'], [], '', false);
+        $mockedRequest->expects($this->once())->method('hasArgument')->with('currentPage')->willReturn(true);
+        $mockedRequest->expects($this->once())->method('getArgument')->with('currentPage')->willReturn(2);
+
         $mockedRepository = $this->getAccessibleMock(AddressRepository::class, ['getAddressesByCustomSorting', 'findByDemand'], [], '', false);
         $mockedRepository->expects($this->any())->method('findByDemand')->willReturn([]);
         $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple'], [], '', false);
@@ -359,6 +374,7 @@ class AddressControllerTest extends BaseTestCase
         $subject->_set('settings', $settings);
         $subject->_set('addressRepository', $mockedRepository);
         $subject->_set('view', $mockedView);
+        $subject->_set('request', $mockedRequest);
 
         $subject->listAction(['not', 'empty']);
     }

--- a/Tests/Unit/Controller/AddressControllerTest.php
+++ b/Tests/Unit/Controller/AddressControllerTest.php
@@ -273,8 +273,6 @@ class AddressControllerTest extends BaseTestCase
         $mockedView->expects($this->once())->method('assignMultiple')->with($assignments);
 
         $mockedRequest = $this->getAccessibleMock(Request::class, ['hasArgument', 'getArgument'], [], '', false);
-        $mockedRequest->expects($this->once())->method('hasArgument')->with('currentPage')->willReturn(true);
-        $mockedRequest->expects($this->once())->method('getArgument')->with('currentPage')->willReturn(2);
 
         $subject = $this->getAccessibleMock(AddressController::class, ['createDemandFromSettings'], [], '', false);
         $subject->expects($this->once())->method('createDemandFromSettings')->willReturn($demand);
@@ -307,8 +305,6 @@ class AddressControllerTest extends BaseTestCase
         ];
 
         $mockedRequest = $this->getAccessibleMock(Request::class, ['hasArgument', 'getArgument'], [], '', false);
-        $mockedRequest->expects($this->once())->method('hasArgument')->with('currentPage')->willReturn(true);
-        $mockedRequest->expects($this->once())->method('getArgument')->with('currentPage')->willReturn(2);
 
         $mockedView = $this->getAccessibleMock(TemplateView::class, ['assignMultiple'], [], '', false);
         $mockedView->expects($this->once())->method('assignMultiple')->with($assignments);
@@ -354,8 +350,6 @@ class AddressControllerTest extends BaseTestCase
     public function overrideDemandMethodIsCalledIfEnabled()
     {
         $mockedRequest = $this->getAccessibleMock(Request::class, ['hasArgument', 'getArgument'], [], '', false);
-        $mockedRequest->expects($this->once())->method('hasArgument')->with('currentPage')->willReturn(true);
-        $mockedRequest->expects($this->once())->method('getArgument')->with('currentPage')->willReturn(2);
 
         $mockedRepository = $this->getAccessibleMock(AddressRepository::class, ['getAddressesByCustomSorting', 'findByDemand'], [], '', false);
         $mockedRepository->expects($this->any())->method('findByDemand')->willReturn([]);


### PR DESCRIPTION
If TYPO3 11 is used, the setting `newPagination` must be ignored as it
is the only option anyway.

Resolves: #377