### PR TITLE
[FEATURE] Allow editors to maintain instagram profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.Build/
+.php-cs-fixer.cache
+composer.lock
+
 /Build/Local/report
 /Build/Local/.phpunit.result.cache
 /Documentation-GENERATED-temp

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+/**
+ * This file represents the configuration for Code Sniffing PSR-2-related
+ * automatic checks of coding guidelines
+ * Install @fabpot's great php-cs-fixer tool via
+ *
+ *  $ composer global require friendsofphp/php-cs-fixer
+ *
+ * And then simply run
+ *
+ *  $ php-cs-fixer fix --config .php_cs
+ *
+ * For more information read:
+ * 	 http://www.php-fig.org/psr/psr-2/
+ * 	 http://cs.sensiolabs.org
+ */
+
+if (PHP_SAPI !== 'cli') {
+    die('This script supports command line usage only. Please check your command.');
+}
+// Define in which folders to search and which folders to exclude
+// Exclude some directories that are excluded by Git anyways to speed up the sniffing
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor/')
+    ->in(__DIR__);
+
+// Return a Code Sniffing configuration using
+// all sniffers needed for PSR-2
+// and additionally:
+//  - Remove leading slashes in use clauses.
+//  - PHP single-line arrays should not have trailing comma.
+//  - Single-line whitespace before closing semicolon are prohibited.
+//  - Remove unused use statements in the PHP source code
+//  - Ensure Concatenation to have at least one whitespace around
+//  - Remove trailing whitespace at the end of blank lines.
+$config = new PhpCsFixer\Config();
+return $config
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        'no_leading_import_slash' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_unused_imports' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'no_whitespace_in_blank_line' => true,
+        'ordered_imports' => true,
+        'single_quote' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'whitespace_after_comma_in_array' => true,
+        'function_typehint_space' => true,
+        'single_line_comment_style' => true,
+        'no_alias_functions' => true,
+        'lowercase_cast' => true,
+        'no_leading_namespace_whitespace' => true,
+        'native_function_casing' => true,
+        'self_accessor' => true,
+        'no_short_bool_cast' => true,
+        'no_unneeded_control_parentheses' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_trim' => true
+    ])
+    ->setFinder($finder);

--- a/Classes/Command/GeocodeCommand.php
+++ b/Classes/Command/GeocodeCommand.php
@@ -21,7 +21,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class GeocodeCommand extends Command
 {
-
     /**
      * Defines the allowed options for this command
      *

--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -33,7 +33,6 @@ use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
  */
 class AddressController extends ActionController
 {
-
     /** @var AddressRepository */
     protected $addressRepository;
 
@@ -71,7 +70,6 @@ class AddressController extends ActionController
     /**
      * Lists addresses by settings in waterfall principle.
      * singleRecords take precedence over categories which take precedence over records from pages
-     *
      */
     public function listAction(?array $override = [])
     {

--- a/Classes/Database/QueryGenerator.php
+++ b/Classes/Database/QueryGenerator.php
@@ -19,7 +19,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class QueryGenerator
 {
-
     /**
      * Recursively fetch all descendants of a given page
      *

--- a/Classes/Domain/Model/Address.php
+++ b/Classes/Domain/Model/Address.php
@@ -21,7 +21,6 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
  */
 class Address extends AbstractEntity
 {
-
     /**
      * Hidden
      *
@@ -663,5 +662,4 @@ class Address extends AbstractEntity
     {
         $this->instagram = $instagram;
     }
-
 }

--- a/Classes/Domain/Model/Address.php
+++ b/Classes/Domain/Model/Address.php
@@ -135,6 +135,11 @@ class Address extends AbstractEntity
     /**
      * @var string
      */
+    protected $instagram = '';
+
+    /**
+     * @var string
+     */
     protected $linkedin = '';
 
     /**
@@ -642,4 +647,21 @@ class Address extends AbstractEntity
             $this->country,
         ]));
     }
+
+    /**
+     * @return string
+     */
+    public function getInstagram(): string
+    {
+        return $this->instagram;
+    }
+
+    /**
+     * @param string $instagram
+     */
+    public function setInstagram(string $instagram): void
+    {
+        $this->instagram = $instagram;
+    }
+
 }

--- a/Classes/Domain/Model/Dto/Demand.php
+++ b/Classes/Domain/Model/Dto/Demand.php
@@ -11,7 +11,6 @@ namespace FriendsOfTYPO3\TtAddress\Domain\Model\Dto;
  */
 class Demand
 {
-
     /** @var array */
     protected $pages = [];
 

--- a/Classes/Domain/Repository/AddressRepository.php
+++ b/Classes/Domain/Repository/AddressRepository.php
@@ -24,7 +24,6 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  */
 class AddressRepository extends Repository
 {
-
     /**
      * override the storagePid settings (do not use storagePid) of extbase
      */

--- a/Classes/Evaluation/LatitudeEvaluation.php
+++ b/Classes/Evaluation/LatitudeEvaluation.php
@@ -17,7 +17,6 @@ use FriendsOfTYPO3\TtAddress\Utility\EvalcoordinatesUtility;
  */
 class LatitudeEvaluation
 {
-
     /**
      * JavaScript code for client side validation/evaluation
      *

--- a/Classes/Evaluation/LongitudeEvaluation.php
+++ b/Classes/Evaluation/LongitudeEvaluation.php
@@ -17,7 +17,6 @@ use FriendsOfTYPO3\TtAddress\Utility\EvalcoordinatesUtility;
  */
 class LongitudeEvaluation
 {
-
     /**
      * JavaScript code for client side validation/evaluation
      *

--- a/Classes/Evaluation/TelephoneEvaluation.php
+++ b/Classes/Evaluation/TelephoneEvaluation.php
@@ -18,7 +18,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TelephoneEvaluation
 {
-
     /** @var Settings */
     protected $extensionSettings;
 

--- a/Classes/Hooks/Tca/AddFieldsToSelector.php
+++ b/Classes/Hooks/Tca/AddFieldsToSelector.php
@@ -16,7 +16,6 @@ use TYPO3\CMS\Core\Localization\LanguageService;
  */
 class AddFieldsToSelector
 {
-
     /** @var LanguageService */
     protected $languageService;
 

--- a/Classes/Service/CategoryService.php
+++ b/Classes/Service/CategoryService.php
@@ -22,7 +22,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class CategoryService
 {
-
     /** @var TimeTracker */
     protected $timeTracker;
 

--- a/Classes/Service/GeocodeService.php
+++ b/Classes/Service/GeocodeService.php
@@ -25,7 +25,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class GeocodeService implements SingletonInterface
 {
-
     /** @var int */
     protected $cacheTime = 7776000;
 

--- a/Classes/Utility/PropertyModification.php
+++ b/Classes/Utility/PropertyModification.php
@@ -15,7 +15,6 @@ namespace FriendsOfTYPO3\TtAddress\Utility;
  */
 class PropertyModification
 {
-
     /**
      * Get cleaned number of a given telephone, fax or mobile number.
      * It removes all chars which are not possible to enter on your cell phone.

--- a/Classes/Utility/TypoScript.php
+++ b/Classes/Utility/TypoScript.php
@@ -16,7 +16,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TypoScript
 {
-
     /**
      * @param array $previousData
      * @param array $tsData

--- a/Configuration/TCA/tt_address.php
+++ b/Configuration/TCA/tt_address.php
@@ -479,6 +479,20 @@ return [
                 ],
             ]
         ],
+        'instagram' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:tt_address/Resources/Private/Language/locallang_db.xlf:tt_address.instagram',
+            'config' => [
+                'type' => 'input',
+                'size' => 20,
+                'eval' => 'trim',
+                'max' => 255,
+                'placeholder' => 'johndoe',
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
+        ],
         'linkedin' => [
             'exclude' => true,
             'label' => 'LLL:EXT:tt_address/Resources/Private/Language/locallang_db.xlf:tt_address.linkedin',
@@ -676,7 +690,7 @@ return [
         ],
         'social' => [
             'showitem' => 'skype, twitter, --linebreak--,
-                            facebook, linkedin'
+                            facebook, instagram, linkedin'
         ],
         'paletteHidden' => [
             'showitem' => 'hidden',

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -45,6 +45,9 @@
       <trans-unit id="label.facebook" xml:space="preserve" translate="no">
         <source>Facebook</source>
       </trans-unit>
+      <trans-unit id="label.instagram" xml:space="preserve" translate="no">
+        <source>Instagram</source>
+      </trans-unit>
       <trans-unit id="label.linkedin" xml:space="preserve" translate="no">
         <source>LinkedIn</source>
       </trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -60,6 +60,9 @@
             <trans-unit id="tt_address.facebook">
                 <source>Facebook</source>
             </trans-unit>
+            <trans-unit id="tt_address.instagram">
+                <source>Instagram</source>
+            </trans-unit>
             <trans-unit id="tt_address.linkedin">
                 <source>LinkedIn</source>
             </trans-unit>

--- a/Resources/Private/Partials/Address.html
+++ b/Resources/Private/Partials/Address.html
@@ -99,6 +99,14 @@
                     <meta itemprop="sameAs" content="https://www.facebook.com/{address.facebook}"/>
                 </li>
             </f:if>
+            <f:if condition="{address.instagram}">
+                <li class="list-inline-item">
+                    <i class="fab fa-instagram" aria-hidden title="{f:translate(key:'label.instagram')}"></i>
+                    <span class="sr-only">{f:translate(key:'label.instagram')}:</span>
+                    <a href="https://www.instagram.com/{address.instagram}" target="_blank">{address.instagram}</a>
+                    <meta itemprop="sameAs" content="https://www.instagram.com/{address.instagram}"/>
+                </li>
+            </f:if>
             <f:if condition="{address.linkedin}">
                 <li class="list-inline-item">
                     <i class="fab fa-linkedin" aria-hidden title="{f:translate(key:'label.linkedin')}"></i>

--- a/Tests/Functional/Repository/AddressRepositoryTest.php
+++ b/Tests/Functional/Repository/AddressRepositoryTest.php
@@ -20,7 +20,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class AddressRepositoryTest extends FunctionalTestCase
 {
-
     /** @var AddressRepository */
     protected $addressRepository;
 

--- a/Tests/Functional/Service/CategoryServiceTest.php
+++ b/Tests/Functional/Service/CategoryServiceTest.php
@@ -18,7 +18,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 class CategoryServiceTest extends FunctionalTestCase
 {
-
     /** @var CategoryService */
     protected $subject;
 

--- a/Tests/Unit/Command/GeocodeCommandTest.php
+++ b/Tests/Unit/Command/GeocodeCommandTest.php
@@ -17,7 +17,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class GeocodeCommandTest extends BaseTestCase
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Domain/Model/AddressTest.php
+++ b/Tests/Unit/Domain/Model/AddressTest.php
@@ -299,6 +299,16 @@ class AddressTest extends BaseTestCase
     /**
      * @test
      */
+    public function instagramCanBeSet()
+    {
+        $value = 'johndoe';
+        $this->subject->setInstagram($value);
+        $this->assertEquals($value, $this->subject->getInstagram());
+    }
+
+    /**
+     * @test
+     */
     public function wrongTwitterHandleThrowsErrorCanBeSet()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/Tests/Unit/Domain/Model/AddressTest.php
+++ b/Tests/Unit/Domain/Model/AddressTest.php
@@ -18,7 +18,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class AddressTest extends BaseTestCase
 {
-
     /** @var Address */
     protected $subject;
 

--- a/Tests/Unit/Domain/Model/Dto/DemandTest.php
+++ b/Tests/Unit/Domain/Model/Dto/DemandTest.php
@@ -14,7 +14,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class DemandTest extends BaseTestCase
 {
-
     /** @var Demand */
     protected $subject;
 

--- a/Tests/Unit/Hooks/Tca/AddFieldsToSelectorTest.php
+++ b/Tests/Unit/Hooks/Tca/AddFieldsToSelectorTest.php
@@ -15,7 +15,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class AddFieldsToSelectorTest extends BaseTestCase
 {
-
     /**
      * @test
      */

--- a/Tests/Unit/Seo/AddressTitleProviderTest.php
+++ b/Tests/Unit/Seo/AddressTitleProviderTest.php
@@ -15,7 +15,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class AddressTitleProviderTest extends BaseTestCase
 {
-
     /**
      * @test
      * @dataProvider addressTitleProvider

--- a/Tests/Unit/Utility/EvalcoordinatesUtilityTest.php
+++ b/Tests/Unit/Utility/EvalcoordinatesUtilityTest.php
@@ -14,7 +14,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class EvalcoordinatesUtilityTest extends BaseTestCase
 {
-
     /**
      * @param $given
      * @param $expected

--- a/Tests/Unit/Utility/TypoScriptTest.php
+++ b/Tests/Unit/Utility/TypoScriptTest.php
@@ -14,7 +14,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class TypoScriptTest extends BaseTestCase
 {
-
     /**
      * @test
      */

--- a/Tests/UnitDeprecated/FormEngine/FieldControl/LocationMapWizardTest.php
+++ b/Tests/UnitDeprecated/FormEngine/FieldControl/LocationMapWizardTest.php
@@ -16,7 +16,6 @@ use TYPO3\TestingFramework\Core\BaseTestCase;
 
 class LocationMapWizardTest extends BaseTestCase
 {
-
     /**
      * @test
      */

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
 		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.0.1",
 		"typo3/cms-extensionmanager": "^11.5 || ^12",
 		"php-coveralls/php-coveralls": "^2.1",
-		"phpspec/prophecy-phpunit": "^2.0"
+		"phpspec/prophecy-phpunit": "^2.0",
+		"friendsofphp/php-cs-fixer": "^3"
 	},
 	"config": {
 		"vendor-dir": ".Build/vendor",

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -29,6 +29,7 @@ CREATE TABLE tt_address (
     skype varchar(255) DEFAULT '',
     twitter varchar(255) DEFAULT '',
     facebook varchar(255) DEFAULT '',
+    instagram varchar(255) DEFAULT '',
     linkedin varchar(255) DEFAULT '',
     latitude decimal(10,8) default NULL,
     longitude decimal(11,8) default NULL,


### PR DESCRIPTION
The feature adds an additional field to the address records to allow editors to maintain instagram profiles and integrate them on the website.

This also adds an updated version of the php cs-fixer configuration file to use the current stable version.

# Checklist
-[x] Create a topic branch from where you want to base your work.
-[x] Make commits of logical units.
-[x] Use php-cs-fixer to make sure the code is formatted correctly.
-[x] Make sure your commit messages are in the proper format.
-[x] Make sure you have added the necessary tests for your changes.
-[x] Run all the tests to assure nothing else was accidentally broken. However travis will do that for you as well.