### PR TITLE
PHP Warning: Undefined array key "singleRecords" in AddressController…

### DIFF
--- a/Classes/Controller/AddressController.php
+++ b/Classes/Controller/AddressController.php
@@ -161,7 +161,7 @@ class AddressController extends ActionController
         if ($this->settings['pages']) {
             $demand->setPages($this->getPidList());
         }
-        $demand->setSingleRecords((string)$this->settings['singleRecords']);
+        $demand->setSingleRecords((string)($this->settings['singleRecords'] ?? ''));
         $demand->setSortBy((string)($this->settings['sortBy'] ?? ''));
         $demand->setSortOrder((string)($this->settings['sortOrder'] ?? ''));
         $demand->setIgnoreWithoutCoordinates((bool)($this->settings['ignoreWithoutCoordinates'] ?? false));


### PR DESCRIPTION
….php line 165

Bug Report
Current Behavior
After updating to TYPO3 v11 and PHP 8.1 I get this error about the array key (like many times in PHP ^8.0)

PHP Warning: Undefined array key "singleRecords" in /typo3conf/ext/tt_address/Classes/Controller/AddressController.php line 165 Expected behavior/output
It happens right after creating a list view plugin with a single address inside.