### PR TITLE
[BUGFIX] Set localization mode for gender to exclude

### DIFF
--- a/Configuration/TCA/tt_address.php
+++ b/Configuration/TCA/tt_address.php
@@ -214,6 +214,7 @@ return [
         ],
         'gender' => [
             'label' => 'LLL:EXT:tt_address/Resources/Private/Language/locallang_db.xlf:tt_address.gender',
+            'l10n_mode' => 'exclude',
             'l10n_display' => 'defaultAsReadonly',
             'config' => [
                 'type' => 'radio',


### PR DESCRIPTION
This will copy the field value of the default language record over to the field of the localized record. Since today, it is possible that the gender changes for a single person, and this should also synchronize with translations of the record.

Resolves: #448