### PR TITLE
[TASK] Migrate custom form field evaluation (returnFieldJS)

### DIFF
--- a/Classes/Evaluation/LatitudeEvaluation.php
+++ b/Classes/Evaluation/LatitudeEvaluation.php
@@ -17,7 +17,6 @@ use FriendsOfTYPO3\TtAddress\Utility\EvalcoordinatesUtility;
  */
 class LatitudeEvaluation
 {
-
     /**
      * Server-side validation/evaluation on saving the record
      * Tests if latutide is between -90 and +90, fills up with zeros to mach decimal (14,12) in database

--- a/Classes/Evaluation/LatitudeEvaluation.php
+++ b/Classes/Evaluation/LatitudeEvaluation.php
@@ -19,19 +19,6 @@ class LatitudeEvaluation
 {
 
     /**
-     * JavaScript code for client side validation/evaluation
-     *
-     * @return string JavaScript code for client side validation/evaluation
-     */
-    public function returnFieldJS()
-    {
-        // Nice to have: add javascript-code for evalution on blur
-        return '
-      return value;
-    ';
-    }
-
-    /**
      * Server-side validation/evaluation on saving the record
      * Tests if latutide is between -90 and +90, fills up with zeros to mach decimal (14,12) in database
      *

--- a/Classes/Evaluation/LongitudeEvaluation.php
+++ b/Classes/Evaluation/LongitudeEvaluation.php
@@ -17,20 +17,6 @@ use FriendsOfTYPO3\TtAddress\Utility\EvalcoordinatesUtility;
  */
 class LongitudeEvaluation
 {
-
-    /**
-     * JavaScript code for client side validation/evaluation
-     *
-     * @return string JavaScript code for client side validation/evaluation
-     */
-    public function returnFieldJS()
-    {
-        // Nice to have: add javascript-code for evaluation on blur
-        return '
-      return value;
-    ';
-    }
-
     /**
      * Server-side validation/evaluation on saving the record
      * Tests if latitude is between -90 and +90, fills up with zeros to mach decimal (14,12) in database

--- a/Classes/Evaluation/TelephoneEvaluation.php
+++ b/Classes/Evaluation/TelephoneEvaluation.php
@@ -20,7 +20,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class TelephoneEvaluation
 {
-
     /** @var Settings */
     protected $extensionSettings;
 

--- a/Classes/Evaluation/TelephoneEvaluation.php
+++ b/Classes/Evaluation/TelephoneEvaluation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace FriendsOfTYPO3\TtAddress\Evaluation;
 
 use FriendsOfTYPO3\TtAddress\Domain\Model\Dto\Settings;
+use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -29,14 +31,18 @@ class TelephoneEvaluation
 
     /**
      * JavaScript code for client side validation/evaluation
-     *
-     * @return string JavaScript code for client side validation/evaluation
      */
-    public function returnFieldJS()
+    public function returnFieldJS(): JavaScriptModuleInstruction
     {
-        return '
-         return value.replace(' . $this->extensionSettings->getTelephoneValidationPatternForJs() . ', "");
-      ';
+        GeneralUtility::makeInstance(PageRenderer::class)->addInlineSetting(
+            'TtAddress.Evaluation',
+            'telephoneValidationPattern',
+            $this->extensionSettings->getTelephoneValidationPatternForJs()
+        );
+        return JavaScriptModuleInstruction::create(
+            '@friendsoftypo3/tt-address/telephone-evaluation.js',
+            'TelephoneEvaluation'
+        );
     }
 
     /**

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,0 +1,9 @@
+<?php
+defined('TYPO3') or die();
+
+return [
+    'dependencies' => ['core'],
+    'imports' => [
+        '@friendsoftypo3/tt-address/' => 'EXT:tt_address/Resources/Public/JavaScript/esm/',
+    ],
+];

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3') or die();
+defined('TYPO3') or die;
 
 return [
     'dependencies' => ['core'],

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -2,7 +2,6 @@
 defined('TYPO3') or die;
 
 return [
-    'dependencies' => ['core'],
     'imports' => [
         '@friendsoftypo3/tt-address/' => 'EXT:tt_address/Resources/Public/JavaScript/esm/',
     ],

--- a/Resources/Public/JavaScript/esm/telephone-evaluation.js
+++ b/Resources/Public/JavaScript/esm/telephone-evaluation.js
@@ -1,0 +1,17 @@
+import FormEngineValidation from '@typo3/backend/form-engine-validation.js';
+
+export class TelephoneEvaluation {
+    static registerCustomEvaluation(name) {
+        FormEngineValidation.registerCustomEvaluation(name, TelephoneEvaluation.applyTelephoneValidationPattern);
+    }
+
+    static applyTelephoneValidationPattern(value) {
+        const items = TYPO3.settings.TtAddress.Evaluation.telephoneValidationPattern.split('/');
+        // fetch RegExp modifier and remove it
+        const modifier = items.pop();
+        // remove first item
+        items.shift();
+        const expression = new RegExp(items.join('/'), modifier);
+        return value.replace(expression, '');
+    }
+}


### PR DESCRIPTION
* migrate inline JavaScript to ES6 module
* remove superfluous empty `returnFieldJS()` methods

Additionally https://review.typo3.org/c/Packages/TYPO3.CMS/+/79017 is required for correctly loading requireJS with CSP nonce values.