### PR TITLE
[BUGFIX] Cannot add new address record in TYPO3 v12 PHP 8.2

### DIFF
--- a/Classes/Hooks/Tca/Label.php
+++ b/Classes/Hooks/Tca/Label.php
@@ -12,7 +12,6 @@ namespace FriendsOfTYPO3\TtAddress\Hooks\Tca;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 /**
  * Dynamic label of the address record based on tsconfig

--- a/Classes/Hooks/Tca/Label.php
+++ b/Classes/Hooks/Tca/Label.php
@@ -30,7 +30,12 @@ class Label
             return;
         }
 
-        $row = BackendUtility::getRecord('tt_address', (int) $params['row']['uid']);
+        if (is_numeric($params['row']['uid'])) {
+            $row = BackendUtility::getRecord('tt_address', (int) $params['row']['uid']);
+        } else {
+            $row = $params['row'];
+        }
+
         $configuration = $this->getConfiguration((int) $row['pid']);
         if (!$configuration) {
             return;


### PR DESCRIPTION
The code has been adjusted to handle situations where the UID is not numeric in the Label.php class (e.g. a new record). Instead of directly casting the UID to an integer, it is first checked whether the UID is numeric. If it is not, the row is fetched directly from the parameters. This aims to prevent potential casting errors and provides more robust handling for uid parameters.

Resolves: #511