### PR TITLE
Prevent Fatal Error in TYPO3 12.4

### DIFF
--- a/Classes/Command/GeocodeCommand.php
+++ b/Classes/Command/GeocodeCommand.php
@@ -43,7 +43,7 @@ class GeocodeCommand extends Command
      * @inheritdoc
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->getGeocodeService($input->getArgument('key'))->calculateCoordinatesForAllRecordsInTable();
         return 0;


### PR DESCRIPTION
Prevents the following error with PHP 8.2 and TYPO3 12.4.10:

Fatal error: Declaration of FriendsOfTYPO3\TtAddress\Command\GeocodeCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /var/www/html/vendor/friendsoftypo3/tt-address/Classes/Command/GeocodeCommand.php on line 46