### PR TITLE
Explicitly require symfony/console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"typo3/cms-core": "^11.5 || ^12.4",
-		"php": ">=7.4"
+		"php": ">=7.4",
+		"symfony/console": "^5.4 || ^6.0 || ^7.0"
 	},
 	"extra": {
 		"typo3/cms": {


### PR DESCRIPTION
This clarifies compatibility and avoids unexpected updates.

See https://github.com/FriendsOfTYPO3/tt_address/pull/516