### PR TITLE
[BUGFIX] Make preview renderer compatible with v12.4.17

### DIFF
--- a/Classes/FormEngine/TtAddressPreviewRenderer.php
+++ b/Classes/FormEngine/TtAddressPreviewRenderer.php
@@ -13,6 +13,7 @@ namespace FriendsOfTYPO3\TtAddress\FormEngine;
 use Doctrine\DBAL\Connection;
 use TYPO3\CMS\Backend\Preview\StandardContentPreviewRenderer;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Backend\View\BackendLayout\Grid\GridColumnItem;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 use TYPO3\CMS\Core\Service\FlexFormService;
@@ -42,10 +43,10 @@ class TtAddressPreviewRenderer extends StandardContentPreviewRenderer
         ],
     ];
 
-    protected function renderContentElementPreviewFromFluidTemplate(array $row): ?string
+    protected function renderContentElementPreviewFromFluidTemplate(array $row, ?GridColumnItem $item = null): ?string
     {
         $row = $this->enrichRow($row);
-        return parent::renderContentElementPreviewFromFluidTemplate($row);
+        return parent::renderContentElementPreviewFromFluidTemplate($row, $item);
     }
 
     protected function enrichRow(array $row): array


### PR DESCRIPTION
In TYPO3 v12.4.17 the method `StandardContentPreviewRenderer::renderContentElementPreviewFromFluidTemplate` has [been changed](https://github.com/TYPO3/typo3/commit/a96746560a5bd9877a91e35ea5ce86432c12c996#diff-cb640d568c5e22f675f12a05f845b81306fd169f2296180ea6b9bcb681843823L249). This PR makes the `TtAddressPreviewRenderer` compatible again.

