### PR TITLE
[BUGFIX] Fixes unspecific Category Class

### DIFF
--- a/Classes/Domain/Model/Address.php
+++ b/Classes/Domain/Model/Address.php
@@ -128,7 +128,7 @@ class Address extends AbstractEntity
     /** @var string */
     protected $description = '';
 
-    /** @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<Category> */
+    /** @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\TYPO3\CMS\Extbase\Domain\Model\Category> */
     protected $categories;
 
     public function __construct()


### PR DESCRIPTION
Fixes Extbase sometimes assumes the Category class is found in same folder as Address. To fix this, we use the FQDN of the Category class.
I sadly cannot state the clear circumstances, we encountered this error on TYPO3 11.5.41 and done this patch to fix it.
Nevertheless i think its never wrong to put the FQDN in the ObjectStorage generic, i think it just has been done by accident in commit https://github.com/FriendsOfTYPO3/tt_address/commit/4341d2ec4301f7ac8537c2277b7de89fc9761081.