### PR TITLE
[BUGFIX] display marker by geocodeUrl

### DIFF
--- a/Resources/Public/JavaScript/esm/leaflet-backend.js
+++ b/Resources/Public/JavaScript/esm/leaflet-backend.js
@@ -87,14 +87,14 @@ class LeafletBackendModule {
     document.body.appendChild(locationMapDiv);
   }
 
-  createMap() {
+  async createMap() {
     if (
       (!this.latitude ||
         !this.longitude ||
         (this.latitude == 0 && this.longitude == 0)) &&
       this.geoCodeUrl != null
     ) {
-      this.geocode();
+      await this.geocode();
     }
 
     // The ultimate fallback: if one of the coordinates is empty, fallback to Kopenhagen.


### PR DESCRIPTION
Wait for the promise to resolve, otherwise the fallback location in kopenhagen is displayed as marker